### PR TITLE
Mirror of dominikh go-tools PR IssueNumber 883

### DIFF
--- a/staticcheck/doc.go
+++ b/staticcheck/doc.go
@@ -358,6 +358,20 @@ falsify results.`,
 
 	"SA4008": {
 		Title: `The variable in the loop condition never changes, are you incrementing the wrong variable?`,
+		Text: `This happens if the code changes the wrong variable in a
+loop, such as:
+
+    for i := 0; i < 10; x++ { /* ... loop body ... */ }
+
+This will be an infinite loop at runtime. This error also occurs for
+loops that unconditionally exit, such as with panic or break:
+
+    for i := 0; i < 10; i++ {
+      break
+    }
+
+These loops are only ever executed once. To fix the warning, remove
+the loop.`,
 		Since: "2017.1",
 	},
 


### PR DESCRIPTION
Mirror of dominikh go-tools PR IssueNumber 883
The warning SA4008 "variable in loop condition never changes" is
triggered when a loop has an unconditional exit, such as a break
or panic. Since the warning is logged on the line of the loop
which could be far from the unconditional exit, it some cases at
first glance it appears this warning is wrong. To help, add
documentation showing that this triggers for unconditional exits.
This should help the next person who runs into this.

This was the cause of a "false positive" bug that was closed as
working as intended: https://github.com/dominikh/go-tools/issues/868
